### PR TITLE
Add resume page

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,6 +122,12 @@
               <i class="fab icon-note fa-2x" aria-hidden="true"></i>
             </a>
           </li>
+            <li>
+              <a href="/resume/" aria-label="Resume"   >
+                <i class="fas fa-file-alt" aria-hidden="true"></i>
+              </a>
+            </li>
+
         
       
     </ul>

--- a/resume/index.html
+++ b/resume/index.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="ja">
+
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <meta name="author" content="Kengo Teshima">
+    <meta name="description" content="Kengo Teshimaの職務経歴書">
+    <meta name="keywords" content="resume,work history">
+
+    <meta name="twitter:card" content="summary"/>
+<meta name="twitter:title" content="職務経歴書"/>
+<meta name="twitter:description" content="Kengo Teshimaの職務経歴書"/>
+
+    <meta property="og:title" content="職務経歴書" />
+<meta property="og:description" content="Kengo Teshimaの職務経歴書" />
+<meta property="og:type" content="website" />
+<meta property="og:url" content="https://KengoTeshima.github.io/resume/" />
+<meta property="og:site_name" content="Kengo Teshima" />
+
+
+
+      <base href="https://KengoTeshima.github.io/resume/">
+
+    <title>職務経歴書 · Kengo Teshima</title>
+
+
+      <link rel="canonical" href="https://KengoTeshima.github.io/resume/">
+
+
+    <link href="https://fonts.googleapis.com/css?family=Lato:400,700%7CMerriweather:300,700%7CSource+Code+Pro:400,700" rel="stylesheet">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.11.2/css/all.css" integrity="sha384-KA6wR/X5RY4zFAHpv/CnoG2UW1uogYfdnP67Uv7eULvTveboZJg0qUpmJZb5VqzN" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css" integrity="sha256-l85OmPOjvil/SOvVt3HnSSjzF1TUMyT9eV0c2BzEGzU=" crossorigin="anonymous" />
+
+
+
+      <link rel="stylesheet" href="/css/coder.min.624134b411585efffadab6a91e7d0383f0d4e22ad49de3690eccbc96f528e670.css" integrity="sha256-YkE0tBFYXv/62rapHn0Dg/DU4irUneNpDsy8lvUo5nA=" crossorigin="anonymous" media="screen" />
+
+
+
+      <link rel="stylesheet" href="/css/custom.css" />
+
+
+
+    <link rel="icon" type="image/png" href="https://KengoTeshima.github.io/images/favicon-32x32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="https://KengoTeshima.github.io/images/favicon-16x16.png" sizes="16x16">
+
+    <meta name="generator" content="Hugo 0.79.1" />
+  </head>
+
+
+
+  <body class="colorscheme-light">
+    <main class="wrapper">
+      <nav class="navigation">
+  <section class="container">
+    <a class="navigation-title" href="/">
+      Kengo Teshima
+    </a>
+
+  </section>
+</nav>
+
+
+      <div class="content">
+
+  <section class="container centered">
+  <div class="resume">
+    <h1>職務経歴書</h1>
+    <p>本ページはKengo Teshimaの職務経歴をまとめています。</p>
+
+    <h2>職務要約</h2>
+    <p>データアナリスト/サイエンティスト/エンジニアとしての経験を活かし、データ活用による課題解決に取り組んできました。</p>
+
+    <h2>職務経歴</h2>
+    <ul>
+      <li>2020年〜現在: 株式会社サンプル - データアナリスト <!-- TODO: 実際の企業名と役職を記載 -->
+      </li>
+      <li>2018年〜2020年: 株式会社サンプル - データサイエンティスト <!-- TODO: 実際の企業名と役職を記載 -->
+      </li>
+    </ul>
+
+    <h2>スキル</h2>
+    <ul>
+      <li>Python</li>
+      <li>R</li>
+      <li>SQL</li>
+    </ul>
+  </div>
+</section>
+
+
+      </div>
+
+      <footer class="footer">
+  <section class="container">
+
+
+
+        © 2020
+
+       Kengo Teshima
+
+
+       ·
+      Powered by <a href="https://gohugo.io/">Hugo</a> & <a href="https://github.com/luizdepra/hugo-coder/">Coder</a>.
+
+
+  </section>
+</footer>
+
+    </main>
+
+
+
+  </body>
+
+</html>


### PR DESCRIPTION
## Summary
- add Japanese resume page with work history and skills
- link to resume page from home page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b84eeef08326b695508b829a3808