### PR TITLE
Display latest updates from SNS on homepage

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -20,3 +20,19 @@
     background-repeat: no-repeat;
     vertical-align: middle;
 }
+.feeds {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 2rem;
+  margin-top: 2rem;
+}
+
+.feed ul {
+  list-style: none;
+  padding-left: 0;
+}
+
+.feed li {
+  margin-bottom: 0.5rem;
+}

--- a/index.html
+++ b/index.html
@@ -135,6 +135,27 @@
   </div>
 </section>
 
+<section class="container">
+  <h2>Latest Updates</h2>
+  <div class="feeds">
+    <div class="feed">
+      <h3>Blog</h3>
+      <ul id="blog-feed"></ul>
+    </div>
+    <div class="feed">
+      <h3>Qiita</h3>
+      <ul id="qiita-feed"></ul>
+    </div>
+    <div class="feed">
+      <h3>note</h3>
+      <ul id="note-feed"></ul>
+    </div>
+  </div>
+  <div class="feed">
+    <h3>Twitter</h3>
+    <a class="twitter-timeline" data-height="300" href="https://twitter.com/ognek4?ref_src=twsrc%5Etfw">Tweets by ognek4</a>
+  </div>
+</section>
 
       </div>
 
@@ -157,7 +178,8 @@
 
     </main>
 
-    
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+<script src="/js/feed.js"></script>
 
   </body>
 

--- a/js/feed.js
+++ b/js/feed.js
@@ -1,0 +1,34 @@
+async function fetchFeed(url, listId, limit = 5) {
+  try {
+    const response = await fetch(url);
+    const text = await response.text();
+    const parser = new DOMParser();
+    const xml = parser.parseFromString(text, 'application/xml');
+    const items = xml.querySelectorAll('item, entry');
+    const list = document.getElementById(listId);
+    items.forEach((item, index) => {
+      if (index >= limit) return;
+      const titleEl = item.querySelector('title');
+      const linkEl = item.querySelector('link');
+      const title = titleEl ? titleEl.textContent : 'No title';
+      let href = '';
+      if (linkEl) {
+        href = linkEl.getAttribute('href') || linkEl.textContent;
+      }
+      const li = document.createElement('li');
+      const a = document.createElement('a');
+      a.href = href;
+      a.textContent = title;
+      li.appendChild(a);
+      list.appendChild(li);
+    });
+  } catch (e) {
+    console.error('Failed to fetch feed', url, e);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  fetchFeed('/index.xml', 'blog-feed');
+  fetchFeed('https://qiita.com/ognek/feed', 'qiita-feed');
+  fetchFeed('https://note.com/ognek4/rss', 'note-feed');
+});


### PR DESCRIPTION
## Summary
- show latest posts from site, Qiita, note, and Twitter
- add styling and JavaScript to load feeds dynamically

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9dea715fc8326adc4ed3975dcb1e2