### PR TITLE
fix: simplify homepage layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@
 
 ## 特徴
 
-- **プロフィール**: 「判断が良くなる仕組み」を軸にした自己紹介
-- **最新情報**: note RSS フィード & X タイムラインを統合表示
-- **Thinking themes**: データ×事業、AI×商取引、行動変容、ジャズとユーモア
+- **ミニマル構成**: 名前・一文・外部リンクだけのトップページ
+- **リンク集**: X / GitHub / LinkedIn / note / YouTube
 - **ダークモード**: ライト/ダーク切り替え対応（localStorage 永続化）
 - **レスポンシブ**: モバイル・デスクトップ両対応
 
@@ -20,19 +19,16 @@
 |------|------|
 | フォント | Manrope + Noto Sans JP (Google Fonts) |
 | アクセント | Signal Coral `#ff6b47` + Acid Lime `#c9f36b` |
-| 背景 (dark) | Warm Ink `#11120f` + editorial grid |
-| カード | Solid bento grid + asymmetric editorial layout |
-| イメージ | 既存ポートレートを主役にしたアーチ型フレーム |
+| 背景 (dark) | Warm Ink `#11120f` |
+| レイアウト | 大きなタイポグラフィ + テキストリンク |
+| イメージ | なし |
 | アニメーション | Intersection Observer による控えめな fade-up |
 
 ## 技術スタック
 
 - **Static HTML/CSS/JS** — ビルドツール不使用、純粋な静的ファイル
 - **ホスティング**: GitHub Pages
-- **フォント**: Google Fonts (Inter)
-- **アイコン**: Font Awesome 6
-- **フィード取得**: RSS/Atom (note) + allorigins.win プロキシ
-- **X**: 埋め込みウィジェット
+- **フォント**: Google Fonts (Manrope / Noto Sans JP)
 
 ## SNS
 
@@ -41,9 +37,8 @@
 | X | [@teshikenn4](https://twitter.com/teshikenn4) |
 | GitHub | [KengoTeshima](https://github.com/KengoTeshima/) |
 | LinkedIn | [kengo-teshima](https://www.linkedin.com/in/kengo-teshima-755aa2141/) |
-| Qiita | [@ognek](https://qiita.com/ognek) |
 | note | [@ognek4](https://note.com/ognek4) |
-| YOUTRUST | [teshikenn](https://youtrust.jp/users/teshikenn) |
+| YouTube | [Drums playlist](https://youtube.com/playlist?list=PLJ99EoR4L7qrZxtqN10wDPz51UBpqKBsa) |
 
 ## ディレクトリ構成
 

--- a/css/custom.css
+++ b/css/custom.css
@@ -2608,3 +2608,223 @@ button:focus-visible {
         transform: none;
     }
 }
+
+/* ============================================================
+   KENGO TESHIMA — MINIMAL SYSTEM v4
+   Type first. No imagery. Almost no prose.
+   ============================================================ */
+
+body {
+    background: var(--bg-primary);
+}
+
+.navigation {
+    position: relative;
+    border-bottom: 1px solid var(--border-default);
+    background: var(--bg-primary);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+}
+
+.navigation .container {
+    min-height: 72px;
+}
+
+.brand-mark {
+    width: 2.15rem;
+    height: 2.15rem;
+    border: 1px solid var(--border-strong);
+    background: transparent;
+    color: var(--text-primary);
+}
+
+.theme-toggle {
+    background: transparent;
+}
+
+.minimal-hero {
+    min-height: calc(100svh - 72px);
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid var(--border-default);
+}
+
+.minimal-hero-inner {
+    padding-top: clamp(4rem, 9vw, 8rem);
+    padding-bottom: clamp(4rem, 9vw, 8rem);
+}
+
+.minimal-kicker,
+.minimal-section-label {
+    color: var(--text-muted);
+    font-size: 0.68rem;
+    font-weight: 800;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+}
+
+.minimal-kicker {
+    margin-bottom: clamp(2rem, 5vw, 4rem);
+}
+
+.minimal-hero h1 {
+    max-width: 12ch;
+    margin: 0;
+    font-size: clamp(5.3rem, 13.5vw, 12rem);
+    font-weight: 650;
+    line-height: 0.78;
+    letter-spacing: -0.09em;
+}
+
+.minimal-hero h1 span {
+    color: var(--accent-primary);
+}
+
+.minimal-statement {
+    margin-top: clamp(2.5rem, 6vw, 4.5rem);
+    color: var(--text-secondary);
+    font-size: clamp(1rem, 1.6vw, 1.25rem);
+    font-weight: 500;
+    letter-spacing: -0.025em;
+}
+
+.scroll-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    margin-top: 2rem;
+    padding-bottom: 0.3rem;
+    border-bottom: 1px solid var(--border-strong);
+    color: var(--text-primary);
+    font-size: 0.72rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.scroll-link:hover {
+    color: var(--accent-primary);
+    border-color: var(--accent-primary);
+}
+
+.minimal-links {
+    padding-top: clamp(5rem, 10vw, 9rem);
+    padding-bottom: clamp(6rem, 12vw, 11rem);
+}
+
+.minimal-section-label {
+    margin-bottom: clamp(2.5rem, 5vw, 4rem);
+}
+
+.link-list {
+    border-top: 1px solid var(--border-strong);
+}
+
+.link-row {
+    display: grid;
+    grid-template-columns: 4rem minmax(0, 1fr) minmax(10rem, 0.7fr) 3rem;
+    align-items: center;
+    gap: 1.5rem;
+    min-height: clamp(6rem, 9vw, 8.25rem);
+    padding: 1rem 0;
+    border-bottom: 1px solid var(--border-default);
+    transition: color 0.25s ease, padding 0.35s var(--ease-out), background 0.25s ease;
+}
+
+.link-row > span:first-child {
+    color: var(--text-muted);
+    font-size: 0.64rem;
+    font-weight: 800;
+    letter-spacing: 0.1em;
+}
+
+.link-row strong {
+    font-size: clamp(2rem, 4.8vw, 4.75rem);
+    font-weight: 600;
+    line-height: 1;
+    letter-spacing: -0.065em;
+}
+
+.link-row small {
+    color: var(--text-muted);
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+}
+
+.link-row i {
+    width: 2.6rem;
+    aspect-ratio: 1;
+    display: grid;
+    place-items: center;
+    justify-self: end;
+    border: 1px solid var(--border-default);
+    border-radius: 50%;
+    color: var(--text-secondary);
+    font-style: normal;
+    transition: transform 0.25s ease, border-color 0.25s ease;
+}
+
+.link-row:hover {
+    padding-inline: 1rem;
+    color: var(--accent-primary);
+    background: var(--bg-subtle);
+}
+
+.link-row:hover small,
+.link-row:hover > span:first-child {
+    color: currentColor;
+}
+
+.link-row:hover i {
+    transform: rotate(45deg);
+    border-color: currentColor;
+    color: currentColor;
+}
+
+.minimal-footer {
+    border-top: 1px solid var(--border-default);
+    background: var(--bg-secondary);
+}
+
+.minimal-footer .container {
+    min-height: 8rem;
+    display: flex;
+    align-items: center;
+    color: var(--text-muted);
+    font-size: 0.64rem;
+    letter-spacing: 0.08em;
+}
+
+@media (max-width: 700px) {
+    .navigation .container {
+        min-height: 64px;
+    }
+
+    .minimal-hero {
+        min-height: calc(100svh - 64px);
+    }
+
+    .minimal-hero h1 {
+        font-size: clamp(4.6rem, 25vw, 7.5rem);
+        line-height: 0.82;
+    }
+
+    .link-row {
+        grid-template-columns: 2.2rem minmax(0, 1fr) 2.5rem;
+        gap: 0.8rem;
+        min-height: 6.25rem;
+    }
+
+    .link-row small {
+        display: none;
+    }
+
+    .link-row strong {
+        font-size: clamp(2.1rem, 11vw, 3.4rem);
+    }
+
+    .link-row:hover {
+        padding-inline: 0.5rem;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -6,20 +6,19 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <meta name="author" content="Kengo Teshima">
-  <meta name="description" content="データ × AI × 事業判断の境界で、判断が良くなる仕組みをつくる Kengo Teshima の個人サイト。">
+  <meta name="description" content="Kengo Teshima — Data, AI, Business.">
   <meta name="keywords" content="kengo teshima,AI,commerce,data,economics,jazz,thinking">
 
   <meta name="twitter:card" content="summary" />
   <meta name="twitter:title" content="Kengo Teshima — 判断が良くなる仕組みをつくる" />
-  <meta name="twitter:description" content="データ × AI × 事業判断の境界で、人と事業が動く理由を構造化します。" />
+  <meta name="twitter:description" content="Data, AI, Business." />
 
   <meta property="og:title" content="Kengo Teshima — 判断が良くなる仕組みをつくる" />
-  <meta property="og:description" content="データ × AI × 事業判断の境界で、人と事業が動く理由を構造化します。" />
+  <meta property="og:description" content="Data, AI, Business." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://KengoTeshima.github.io/" />
   <meta property="og:site_name" content="Kengo Teshima" />
 
-  <base href="https://KengoTeshima.github.io/">
   <title>Kengo Teshima — Data, AI &amp; Decision Design</title>
   <link rel="canonical" href="https://KengoTeshima.github.io/">
 
@@ -27,9 +26,6 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&amp;family=Noto+Sans+JP:wght@400;500;600;700;800&amp;display=swap" rel="stylesheet">
-
-  <!-- Icons -->
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 
   <!-- Styles -->
   <link rel="stylesheet" href="/css/custom.css">
@@ -60,9 +56,7 @@
           <span class="brand-name">Kengo Teshima</span>
         </a>
         <div class="nav-actions">
-          <a class="nav-link" href="#about">About</a>
-          <a class="nav-link" href="#themes">Themes</a>
-          <a class="nav-link" href="#writing">Writing</a>
+          <a class="nav-link" href="#links">Links</a>
           <button class="theme-toggle" id="theme-toggle" aria-label="表示テーマを切り替える">
             <svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24"
               fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -87,197 +81,46 @@
 
     <div class="content">
 
-      <section class="hero" aria-labelledby="hero-title">
-        <div class="container hero-grid">
-          <div class="hero-copy fade-up">
-            <p class="eyebrow"><span class="eyebrow-dot" aria-hidden="true"></span> Data × AI × Business</p>
-            <h1 id="hero-title">判断が良くなる、<br><em>仕組み</em>をつくる。</h1>
-            <p class="hero-lead">
-              データとAIを、精度の話で終わらせない。<br>
-              人と事業が動く理由を構造化し、意思決定から実装までをつなぎます。
-            </p>
-            <div class="hero-actions">
-              <a class="primary-button" href="#writing">最新の思考を読む <span aria-hidden="true">↘</span></a>
-              <a class="text-button" href="#about">私について <span aria-hidden="true">→</span></a>
-            </div>
-            <ul class="social-links" aria-label="ソーシャルリンク">
-              <li><a href="https://twitter.com/teshikenn4/" aria-label="X" target="_blank" rel="noopener noreferrer"><i class="fab fa-x-twitter" aria-hidden="true"></i></a></li>
-              <li><a href="https://github.com/KengoTeshima/" aria-label="GitHub" target="_blank" rel="noopener noreferrer"><i class="fab fa-github" aria-hidden="true"></i></a></li>
-              <li><a href="https://www.linkedin.com/in/kengo-teshima-755aa2141/" aria-label="LinkedIn" target="_blank" rel="noopener noreferrer"><i class="fab fa-linkedin" aria-hidden="true"></i></a></li>
-              <li><a href="https://note.com/ognek4" aria-label="note" target="_blank" rel="noopener noreferrer"><i class="fab icon-note" aria-hidden="true"></i></a></li>
-              <li><a href="https://youtube.com/playlist?list=PLJ99EoR4L7qrZxtqN10wDPz51UBpqKBsa&amp;si=gxa_e9OyVMkxF6_W" aria-label="ドラム演奏" target="_blank" rel="noopener noreferrer"><i class="fas fa-drum" aria-hidden="true"></i></a></li>
-            </ul>
-          </div>
-
-          <div class="hero-visual fade-up" data-delay="120" aria-label="Kengo Teshima のポートレート">
-            <div class="portrait-frame">
-              <img src="/images/avatar.jpg" alt="Kengo Teshima" width="960" height="960">
-              <span class="portrait-index" aria-hidden="true">01 / 04</span>
-            </div>
-            <div class="orbit-card orbit-card-top">
-              <span class="orbit-label">MODE</span>
-              <strong>ABSTRACT ↔ CONCRETE</strong>
-            </div>
-            <div class="orbit-card orbit-card-bottom">
-              <span class="orbit-label">CURRENT</span>
-              <strong>Data Director / FinTech</strong>
-            </div>
-          </div>
-        </div>
-
-        <div class="container thinking-loop fade-up" aria-label="思考のプロセス">
-          <span>Question</span><i aria-hidden="true">→</i>
-          <span>Structure</span><i aria-hidden="true">→</i>
-          <span>Decision</span><i aria-hidden="true">→</i>
-          <span>Action</span>
+      <section class="minimal-hero" aria-labelledby="hero-title">
+        <div class="container minimal-hero-inner fade-up">
+          <p class="minimal-kicker">Data · AI · Business</p>
+          <h1 id="hero-title">Kengo<br>Teshima<span aria-hidden="true">.</span></h1>
+          <p class="minimal-statement">判断が良くなる仕組みをつくる。</p>
+          <a class="scroll-link" href="#links">Links <span aria-hidden="true">↓</span></a>
         </div>
       </section>
 
-      <section id="about" class="container section-shell about-section">
-        <div class="section-kicker fade-up">
-          <span>01</span>
-          <p>What I do</p>
-        </div>
-        <div class="about-grid">
-          <h2 class="display-copy fade-up">人と事業が動く理由を、<br><span>再利用できる構造</span>にする。</h2>
-          <div class="about-body fade-up" data-delay="100">
-            <p>データ分析、機械学習、事業づくり。領域が変わっても、私がやっていることは同じです。曖昧な問いに定義を置き、因果をほどき、判断できる形に変える。</p>
-            <p>NTTデータ、DATUM STUDIO、ZOZOを経て、現在はFinTech企業でデータ部門のディレクターをしています。精度ではなく、事業のPLまでつながる設計に興味があります。</p>
-            <a class="inline-link" href="#writing">最近の文章を見る <span aria-hidden="true">↓</span></a>
-          </div>
-        </div>
-      </section>
-
-      <section id="themes" class="container section-shell themes-section">
-        <div class="section-kicker fade-up">
-          <span>02</span>
-          <p>Thinking themes</p>
-        </div>
-        <div class="theme-grid">
-          <article class="theme-card theme-card-featured fade-up">
-            <div class="theme-meta"><span>01</span><span>CORE</span></div>
-            <div>
-              <p class="theme-icon" aria-hidden="true">↳</p>
-              <h3>Data × Business</h3>
-              <p>分析精度ではなく、意思決定と事業KPIから逆算する。データを「説明」ではなく「動かす仕組み」に変えます。</p>
-            </div>
-            <div class="tag-row"><span>Decision Design</span><span>FinTech</span><span>PL</span></div>
-          </article>
-          <article class="theme-card fade-up" data-delay="80">
-            <div class="theme-meta"><span>02</span><span>FUTURE</span></div>
-            <div>
-              <p class="theme-icon" aria-hidden="true">◎</p>
-              <h3>AI × Commerce</h3>
-              <p>AIエージェントが、探索・比較・購買をどう変えるか。商取引の次の構造を考えます。</p>
-            </div>
-          </article>
-          <article class="theme-card fade-up" data-delay="160">
-            <div class="theme-meta"><span>03</span><span>BEHAVIOR</span></div>
-            <div>
-              <p class="theme-icon" aria-hidden="true">△</p>
-              <h3>Why People Move</h3>
-              <p>合理性だけでは人は動かない。欲、意味、遊びを含めて、行動変容を設計します。</p>
-            </div>
-          </article>
-          <article class="theme-card theme-card-wide fade-up" data-delay="240">
-            <div class="theme-meta"><span>04</span><span>SIDE B</span></div>
-            <div class="theme-wide-copy">
-              <div>
-                <p class="theme-icon" aria-hidden="true">♩</p>
-                <h3>Jazz, Humor &amp; Structure</h3>
-              </div>
-              <p>ジャズの即興も、漫才のズレも、制約の中で生まれる。仕事から遠い場所で見つけた構造を、仕事へ持ち帰ります。</p>
-            </div>
-            <div class="tag-row"><span>Drums</span><span>Improvisation</span><span>Humor</span></div>
-          </article>
-        </div>
-      </section>
-
-      <section id="writing" class="container section-shell latest-updates">
-        <div class="section-kicker fade-up">
-          <span>03</span>
-          <p>Writing &amp; Signals</p>
-        </div>
-        <div class="writing-heading fade-up">
-          <h2>考えていることを、<br>途中のまま外に出す。</h2>
-          <p>完成した答えより、いま立てている問い。noteでは長く、Xでは短く書いています。</p>
-        </div>
-
-        <div class="updates-layout">
-          <div class="note-section fade-up">
-            <div class="feed-card note-card">
-              <div class="feed-header">
-                <div>
-                  <span class="feed-number">LONG FORM</span>
-                  <h3><i class="fab icon-note" aria-hidden="true"></i> note</h3>
-                </div>
-                <span class="feed-arrow" aria-hidden="true">↗</span>
-              </div>
-              <ul id="note-feed" class="feed-list"></ul>
-              <div class="feed-link">
-                <a href="https://note.com/ognek4" target="_blank" rel="noopener noreferrer">
-                  すべての記事を見る <span aria-hidden="true">→</span>
-                </a>
-              </div>
-            </div>
-          </div>
-
-          <div class="x-section fade-up">
-            <div class="feed-header x-header">
-              <div>
-                <span class="feed-number">SHORT FORM</span>
-                <h3><i class="fab fa-x-twitter" aria-hidden="true"></i> X</h3>
-              </div>
-              <span class="feed-arrow" aria-hidden="true">↗</span>
-            </div>
-            <div class="x-container">
-              <a class="twitter-timeline" data-height="480" data-width="100%" data-theme="dark"
-                data-chrome="noheader nofooter transparent" data-border-color="transparent" data-tweet-limit="5"
-                href="https://twitter.com/teshikenn4?ref_src=twsrc%5Etfw">
-                Loading posts by @teshikenn4...
-              </a>
-            </div>
-            <div class="x-link">
-              <a href="https://twitter.com/teshikenn4" target="_blank" rel="noopener noreferrer">
-                @teshikenn4 をフォロー <span aria-hidden="true">→</span>
-              </a>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section class="container contact">
-        <div class="contact-card fade-up">
-          <p class="contact-kicker">LET’S CONNECT</p>
-          <h2>面白い問いがあれば、<br>話しましょう。</h2>
-          <p>データ、AI、事業づくり。その境界にある曖昧なテーマほど好きです。</p>
-          <div class="contact-actions">
-            <a class="primary-button" href="https://www.linkedin.com/in/kengo-teshima-755aa2141/" target="_blank" rel="noopener noreferrer">LinkedInで連絡する <span aria-hidden="true">↗</span></a>
-            <a class="text-button" href="https://twitter.com/teshikenn4" target="_blank" rel="noopener noreferrer">Xで話しかける <span aria-hidden="true">↗</span></a>
+      <section id="links" class="minimal-links">
+        <div class="container fade-up">
+          <p class="minimal-section-label">Links</p>
+          <div class="link-list">
+            <a class="link-row" href="https://twitter.com/teshikenn4" target="_blank" rel="noopener noreferrer">
+              <span>01</span><strong>X</strong><small>@teshikenn4</small><i aria-hidden="true">↗</i>
+            </a>
+            <a class="link-row" href="https://github.com/KengoTeshima" target="_blank" rel="noopener noreferrer">
+              <span>02</span><strong>GitHub</strong><small>KengoTeshima</small><i aria-hidden="true">↗</i>
+            </a>
+            <a class="link-row" href="https://www.linkedin.com/in/kengo-teshima-755aa2141/" target="_blank" rel="noopener noreferrer">
+              <span>03</span><strong>LinkedIn</strong><small>Profile</small><i aria-hidden="true">↗</i>
+            </a>
+            <a class="link-row" href="https://note.com/ognek4" target="_blank" rel="noopener noreferrer">
+              <span>04</span><strong>note</strong><small>@ognek4</small><i aria-hidden="true">↗</i>
+            </a>
+            <a class="link-row" href="https://youtube.com/playlist?list=PLJ99EoR4L7qrZxtqN10wDPz51UBpqKBsa&amp;si=gxa_e9OyVMkxF6_W" target="_blank" rel="noopener noreferrer">
+              <span>05</span><strong>YouTube</strong><small>Drums</small><i aria-hidden="true">↗</i>
+            </a>
           </div>
         </div>
       </section>
 
     </div>
 
-    <footer class="footer">
-      <section class="container footer-grid">
-        <div>
-          <span class="brand-mark">KT</span>
-          <p>判断が良くなる仕組みをつくる。</p>
-        </div>
-        <div class="footer-links">
-          <a href="https://github.com/KengoTeshima" target="_blank" rel="noopener noreferrer">GitHub ↗</a>
-          <a href="https://twitter.com/teshikenn4" target="_blank" rel="noopener noreferrer">X ↗</a>
-          <a href="https://note.com/ognek4" target="_blank" rel="noopener noreferrer">note ↗</a>
-        </div>
-        <p class="footer-copy">© 2026 Kengo Teshima</p>
-      </section>
+    <footer class="minimal-footer">
+      <div class="container">© 2026 Kengo Teshima</div>
     </footer>
 
   </main>
 
-  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
   <script src="/js/feed.js"></script>
 
 </body>


### PR DESCRIPTION
## What changed

- Removed the portrait and all other page imagery
- Reduced the homepage to the name, one short statement, and five external links
- Preserved X, GitHub, LinkedIn, note, and YouTube links
- Removed embedded feeds and long-form profile/theme copy
- Removed the production-only base URL so local preview uses the current stylesheet

## Impact

- No vertically stretched portrait on desktop
- No horizontal overflow at a 1440×900 viewport
- Zero content images and only three short text lines before the links
- Existing light/dark theme and responsive behavior remain available

## Checks

- Browser-verified at 1440×900
- Confirmed zero content images, five link rows, and no console errors
- HTML structure, local assets, external-link safety, CSS balance, and JavaScript syntax validated
- Staged diff scanned for email addresses, phone numbers, street addresses, secret values, credentials, and tracking IDs